### PR TITLE
Hot-fix/on render server unhealthy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "devDependencies": {
         "@babel/core": "^7.22.5",
         "@babel/eslint-parser": "^7.22.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@babel/plugin-syntax-jsx": "^7.22.5",
         "@babel/preset-react": "^7.22.5",
         "eslint": "^7.32.0",
@@ -663,9 +664,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1916,6 +1924,17 @@
         "core-js-compat": "^3.30.2",
         "semver": "^6.3.0"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "engines": {
         "node": ">=6.9.0"
       },

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
   "devDependencies": {
     "@babel/core": "^7.22.5",
     "@babel/eslint-parser": "^7.22.5",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/plugin-syntax-jsx": "^7.22.5",
     "@babel/preset-react": "^7.22.5",
-    "@babel/plugin-proposal-private-property-in-object": "^7.33.1",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-import": "^2.27.5",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/eslint-parser": "^7.22.5",
     "@babel/plugin-syntax-jsx": "^7.22.5",
     "@babel/preset-react": "^7.22.5",
+    "@babel/plugin-proposal-private-property-in-object": "^7.33.1",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-import": "^2.27.5",

--- a/src/services/bookStoreAPI.js
+++ b/src/services/bookStoreAPI.js
@@ -7,6 +7,7 @@ const setBookStoreId = async () => {
   try {
     const bookStoreId = await axios.post(`${bookstoreBaseURL}apps/`);
     localStorage.setItem('bookStoreId', bookStoreId.data);
+    return null;
   } catch (error) {
     return error;
   }

--- a/src/services/bookStoreAPI.js
+++ b/src/services/bookStoreAPI.js
@@ -8,7 +8,7 @@ const setBookStoreId = async () => {
     const bookStoreId = await axios.post(`${bookstoreBaseURL}apps/`);
     localStorage.setItem('bookStoreId', bookStoreId.data);
   } catch (error) {
-    console.error(`setBookStoreId got an error => ${error}`);
+    return error;
   }
 };
 


### PR DESCRIPTION
# 🚩: HOT-FIX: Bookstore-React-App | hot-fix/onRender-server-unhealthy - >>branch<< -

---

## 1# - ERROR on Deploy logs

> Jul 21 06:29:02 PM One of your dependencies, babel-preset-react-app, is importing the
> Jul 21 06:29:02 PM "@babel/plugin-proposal-private-property-in-object" package without
> Jul 21 06:29:02 PM declaring it in its dependencies. This is currently working because
> Jul 21 06:29:02 PM "@babel/plugin-proposal-private-property-in-object" is already in your
> Jul 21 06:29:02 PM node_modules folder for unrelated reasons, but it may break at any time.
> Jul 21 06:29:02 PM  
> Jul 21 06:29:02 PM babel-preset-react-app is part of the create-react-app project, which
> Jul 21 06:29:02 PM is not maintained anymore. It is thus unlikely that this bug will
> Jul 21 06:29:02 PM ever be fixed.
> Jul 21 06:31:32 PM Compiled with warnings.

### 2# - Linter WARNING on Deploy logs

> Jul 21 05:45:43 PM WARNING in [eslint]
> Jul 21 05:45:43 PM src/services/bookStoreAPI.js
> Jul 21 05:45:43 PM Line 11:5: Unexpected console statement no-console

---

## To mitigate this **`error`** and **`warning`** here is a summary of what has been done

### Type of **`files`** changed

![My Skills](https://skillicons.dev/icons?i=js), **`json`**

---

### I have **MODIFIED** the succeeding **\*📂 folders** and/or **📄\*\* files**

# \*📂 root/

### To mitigate error 1#

- **\*\*📄 package-lock.json**
- **\*\*📄 package.json**

  - I have added install the **`@babel/plugin-proposal-private-property-in-object`** package as a **`devDependency`**, with the correct version number.

- ## \*📂 src/

  - ### \*📂 services/

    ### To mitigate warning 2#

    - **\*\*📄 bookStoreAPI.js**

      - I have properly _return_ **null** when try success, and _return_ **error** when try failed.

---
